### PR TITLE
fix(backend): correct port configuration and add missing dependency

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 # Backend Environment Variables
-PORT=5000
+PORT=3001
 NODE_ENV=production
 ML_SERVICE_URL=http://localhost:5000
 CORS_ORIGIN=http://localhost:3000

--- a/backend/package.json
+++ b/backend/package.json
@@ -70,7 +70,8 @@
     "prettier": "^3.1.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.4.5",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
- Updated backend PORT from 5000 to 3001 in .env.example to match docker-compose configuration and prevent port conflict with ML service
- Added ts-node-dev to devDependencies to support the dev script for hot-reloading during development

These changes resolve critical configuration issues that prevented the backend from starting correctly in local development environments.

Technical details:
- Backend service binds to port 3001 per docker-compose.yml
- ML service uses port 5000, causing conflict with old backend configuration
- ts-node-dev is required by 'npm run dev' script but was not declared

Testing:
- All automated tests passing (backend: 3/3, frontend: 1/1, ML service: passed)
- Docker Compose build completed successfully
- All three services built without errors