### PR TITLE
Remove legacy brand colors in v6.0

### DIFF
--- a/frontend/src/components/ui/ThemePreview.tsx
+++ b/frontend/src/components/ui/ThemePreview.tsx
@@ -8,16 +8,6 @@ import { motion } from 'framer-motion';
 export const ThemePreview: React.FC = () => {
   const colorSections = [
     {
-      title: 'Brand Core',
-      colors: [
-        { name: 'Charcoal', value: '#313131', var: '--brand-charcoal' },
-        { name: 'Off-White', value: '#FDFDFC', var: '--brand-offwhite', dark: true },
-        { name: 'Neutral Light', value: '#EDEDEC', var: '--brand-neutral-light', dark: true },
-        { name: 'Neutral Mid', value: '#ADADAD', var: '--brand-neutral-mid' },
-        { name: 'Neutral Dark', value: '#6D6D6C', var: '--brand-neutral-dark' },
-      ],
-    },
-    {
       title: 'Surfaces',
       colors: [
         { name: 'BG-0 (App)', value: '#0B0B0C', var: '--bg-0' },

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -12,15 +12,6 @@
 
 :root {
   /* ============================================
-     BRAND CORE COLORS (from Roneira logo)
-     ============================================ */
-  --brand-charcoal: #313131;
-  --brand-offwhite: #FDFDFC;
-  --brand-neutral-light: #EDEDEC;
-  --brand-neutral-mid: #ADADAD;
-  --brand-neutral-dark: #6D6D6C;
-  
-  /* ============================================
      DARK UI SURFACE TOKENS
      ============================================ */
   --bg-0: #0B0B0C;           /* App background (deepest) */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -127,15 +127,6 @@ module.exports = {
           '100%': { transform: 'translateY(0)', opacity: '1' },
         },
       },
-      // Legacy brand colors kept so old components don't break during migration
-      // TODO: Remove in v6.0 after full migration to MD3 tokens
-      brand: {
-        charcoal: '#313131',
-        offwhite: '#FDFDFC',
-        'neutral-light': '#EDEDEC',
-        'neutral-mid': '#ADADAD',
-        'neutral-dark': '#6D6D6C',
-      },
     },
   },
   plugins: [


### PR DESCRIPTION
This pull request removes the legacy brand color tokens from the frontend as part of the v6.0 cleanup.

Key changes:
- Deleted the `brand` extension in `frontend/tailwind.config.js`.
- Removed legacy `--brand-*` CSS variables from `frontend/src/styles/index.css`.
- Updated `frontend/src/components/ui/ThemePreview.tsx` to remove the defunct "Brand Core" color section.

Verification was performed via recursive `grep` to ensure no active references to these colors remain in the source code. Automated tests and builds were attempted but could not be executed due to missing dependencies and lack of internet access in the sandbox environment. Syntax of the modified `tailwind.config.js` was verified using `node -c`.

---
*PR created automatically by Jules for task [16528764654217200727](https://jules.google.com/task/16528764654217200727) started by @aaron-seq*