### PR TITLE
🧪 test(market): improve unit test coverage for inferExchange logic

### DIFF
--- a/src/lib/market/constants.test.ts
+++ b/src/lib/market/constants.test.ts
@@ -3,7 +3,24 @@ import {
   getPeerConfigs,
   inferAssetType,
   inferCurrency,
+  inferExchange,
 } from "@/lib/market/constants";
+
+describe("inferExchange", () => {
+  it("infers exchange based on symbol suffix or prefix", () => {
+    expect(inferExchange("RELIANCE.NS")).toBe("NSE");
+    expect(inferExchange("TCS.BO")).toBe("BSE");
+    expect(inferExchange("^NSEI")).toBe("INDEX");
+    expect(inferExchange("BTC-USD")).toBe("CRYPTO");
+    expect(inferExchange("EURUSD=X")).toBe("FX");
+    expect(inferExchange("GC=F")).toBe("FUTURES");
+  });
+
+  it("defaults to NASDAQ for unknown formats", () => {
+    expect(inferExchange("AAPL")).toBe("NASDAQ");
+    expect(inferExchange("MSFT")).toBe("NASDAQ");
+  });
+});
 
 describe("market symbol helpers", () => {
   it("normalizes common US equity symbols for provider usage", () => {


### PR DESCRIPTION
🎯 **What:** This PR adds unit test coverage for the pure function `inferExchange` located in `src/lib/market/constants.ts`.

📊 **Coverage:** The tests now explicitly cover the full logic mapping of suffix and prefix patterns to expected exchanges. This includes:
- Suffix `.NS` maps to `NSE`
- Suffix `.BO` maps to `BSE`
- Prefix `^` maps to `INDEX`
- Suffix `-USD` maps to `CRYPTO`
- Includes `=X` maps to `FX`
- Suffix `=F` maps to `FUTURES`
- Unknown ticker patterns default to `NASDAQ`

✨ **Result:** Enhanced test coverage provides a stronger safety net. A future refactor or expansion to the supported market exchanges within this function can proceed confidently because there's explicit confirmation that existing string matching cases correctly resolve.

---
*PR created automatically by Jules for task [8746844501412281831](https://jules.google.com/task/8746844501412281831) started by @aaron-seq*