### PR TITLE
🧪 test(ml-service): add test for batch_predict with empty list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ml/artifacts/generated/
 # Misc
 .DS_Store
 *.log
+venv/

--- a/ml-service/test_enhanced_app.py
+++ b/ml-service/test_enhanced_app.py
@@ -1,0 +1,22 @@
+"""Tests for enhanced_app.py endpoints"""
+
+import pytest
+import json
+from enhanced_app import app
+
+class TestEnhancedApp:
+    def setup_method(self):
+        self.client = app.test_client()
+        self.client.testing = True
+
+    def test_batch_predict_empty_list(self):
+        """Test batch_predict endpoint with an empty list of tickers"""
+        response = self.client.post(
+            "/batch_predict",
+            json={"tickers": []},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "error" in data
+        assert data["error"] == "Ticker list is required"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the `batch_predict` endpoint when an empty list of tickers is provided.
📊 **Coverage:** Covered the edge case of an empty array being sent to the `/batch_predict` endpoint in `enhanced_app.py`.
✨ **Result:** A new test file `test_enhanced_app.py` was created to provide a dedicated test suite for `enhanced_app.py`. The `batch_predict` with empty list scenario is now verified and returns the expected `400 Bad Request` with the `"Ticker list is required"` error payload.

---
*PR created automatically by Jules for task [15722413783226863415](https://jules.google.com/task/15722413783226863415) started by @aaron-seq*