### PR TITLE
🧪 test(ml-service): add batch_predict empty list tests

### DIFF
--- a/ml-service/test_enhanced_app.py
+++ b/ml-service/test_enhanced_app.py
@@ -1,0 +1,33 @@
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+from enhanced_app import app
+
+class TestEnhancedAppBatchPredict:
+    def setup_method(self):
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def test_batch_predict_empty_list(self):
+        """Test batch_predict with empty list"""
+        response = self.client.post(
+            "/batch_predict",
+            json={"tickers": []},
+            content_type="application/json"
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "error" in data
+        assert data["error"] == "Ticker list is required"
+
+    def test_batch_predict_no_tickers_key(self):
+        """Test batch_predict with no tickers key in JSON"""
+        response = self.client.post(
+            "/batch_predict",
+            json={},
+            content_type="application/json"
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "error" in data
+        assert data["error"] == "Ticker list is required"


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap by adding unit tests for the `batch_predict` endpoint in the `ml-service` to specifically cover cases where an empty or missing `tickers` list is provided. 
📊 **Coverage:** Two scenarios are now tested: sending an empty list (`{"tickers": []}`) and sending a payload with a missing tickers key (`{}`).
✨ **Result:** Test coverage for `enhanced_app.py` has been improved, ensuring the endpoint deterministically rejects empty batches with a 400 Bad Request status code and a predictable error message, preventing unhandled internal errors or unexpected behaviour.

---
*PR created automatically by Jules for task [262949220104444406](https://jules.google.com/task/262949220104444406) started by @aaron-seq*