### PR TITLE
Refactor navigation state syncing in App.tsx

### DIFF
--- a/frontend/src/features/Shell/App.tsx
+++ b/frontend/src/features/Shell/App.tsx
@@ -68,17 +68,8 @@ const MainApplicationContent: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Sync active tab with URL location
-  useEffect(() => {
-    const path = location.pathname.substring(1); // remove leading slash
-    if (path) {
-      setActiveNavigationTab(path);
-    }
-  }, [location]);
-
-  // Local state for navigation
-  const [activeNavigationTab, setActiveNavigationTab] =
-    useState<string>("overview");
+  // Derive active tab from URL location
+  const activeNavigationTab = location.pathname.substring(1) || "overview";
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
 
   const initializeApplication = useCallback(async () => {
@@ -121,29 +112,10 @@ const MainApplicationContent: React.FC = () => {
     return () => clearInterval(healthCheckInterval);
   }, [isInitialized, setMarketHealthStatus]);
 
-  // Handle navigation tab changes
+  // Handle navigation tab changes by updating the URL
   const handleNavigationTabChange = useCallback((tabName: string) => {
-    setActiveNavigationTab(tabName);
     navigate(`/${tabName}`);
   }, [navigate]);
-
-  // Wait, I need to use navigate.
-  // I will refactor this in a separate step or just assume the user clicks the tab and it updates state?
-  // Actually, NavigationHeader just calls onTabChange.
-  // The Routes are matched by URL path.
-  // We need to sync `activeNavigationTab` state with URL or vice versa.
-  // For now, let's keep it simple and just rely on the user clicking which updates the internal state 
-  // AND pushes a navigation event?
-  // Ah, the `NavigationHeader` uses simple `button`s.
-  // I should update `handleNavigationTabChange` to actually navigate.
-
-  // Let's fix the logic below this comment block with a proper implementation.
-  // Since I can't use hooks conditionally or easily inside `replace`, 
-  // I will just use `window.history.pushState` or similar if I can't import `useNavigate` easily at top level.
-  // But wait, `MainApplicationContent` IS inside `Router`.
-  // So I can use `useNavigate`.
-
-  // I'll skip this specific Replace and do it properly in the next step.
 
 
   // Show loading spinner during initialization


### PR DESCRIPTION
This PR refactors the navigation state management in `frontend/src/features/Shell/App.tsx`.
It replaces the manual `activeNavigationTab` state and its corresponding `useEffect` sync logic with a derived value from `useLocation().pathname`.
This ensures that the URL remains the single source of truth for the active tab, improving reliability and simplifying the code.
The `handleNavigationTabChange` function now only triggers the `navigate` function.
Obsolete comments have been removed.

---
*PR created automatically by Jules for task [3799742194540441423](https://jules.google.com/task/3799742194540441423) started by @aaron-seq*