### PR TITLE
🔒 fix(realtime): replace overly permissive CORS policy

### DIFF
--- a/realtime/src/server.ts
+++ b/realtime/src/server.ts
@@ -30,7 +30,7 @@ const httpServer = createServer();
 
 const io = new Server(httpServer, {
   cors: {
-    origin: process.env.CORS_ORIGIN || '*',
+    origin: process.env.WS_CORS_ORIGIN || process.env.CORS_ORIGIN || 'http://localhost:3000',
     methods: ['GET', 'POST'],
     credentials: true,
   },


### PR DESCRIPTION
🔒 **What:** Fixed an overly permissive CORS origin policy in the Realtime server (`realtime/src/server.ts`).
⚠️ **Risk:** The previous policy used a wildcard fallback (`'*'`), meaning if `CORS_ORIGIN` was not set, the server would accept cross-origin requests from any domain, potentially allowing malicious sites to connect and steal data or execute actions on behalf of a user.
🛡️ **Solution:** Replaced `process.env.CORS_ORIGIN || '*'` with `process.env.WS_CORS_ORIGIN || process.env.CORS_ORIGIN || 'http://localhost:3000'`. This prioritizes the WebSocket-specific CORS variable, falls back to the general CORS variable, and ultimately defaults to a secure development environment URL (`http://localhost:3000`) instead of a wildcard.

---
*PR created automatically by Jules for task [9037327484200759554](https://jules.google.com/task/9037327484200759554) started by @aaron-seq*