### PR TITLE
🔒 Fix overly permissive CORS policy in ML Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ml/artifacts/generated/
 # Misc
 .DS_Store
 *.log
+ml-service/venv_test/

--- a/ml-service/.gitignore
+++ b/ml-service/.gitignore
@@ -1,0 +1,1 @@
+venv_test/

--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 
 # Initialize Flask application
 finance_intelligence_app = Flask(__name__)
-CORS(finance_intelligence_app, origins="*")
+allowed_origins = os.environ.get("ALLOWED_ORIGINS", "http://localhost:3000,https://roneira.ai").split(",")
+CORS(finance_intelligence_app, origins=allowed_origins)
 
 
 # Configuration

--- a/ml-service/main.py
+++ b/ml-service/main.py
@@ -127,9 +127,12 @@ app = FastAPI(
 )
 
 # CORS configuration
+import os
+allowed_origins = os.environ.get("ALLOWED_ORIGINS", "http://localhost:3000,https://roneira.ai").split(",")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** The CORS policy in the ML Service (both the Flask app in `app.py` and the FastAPI app in `main.py`) was overly permissive, using `origins="*"`.
⚠️ **Risk:** Allowing `*` as an origin enables cross-origin requests from any domain, making the API vulnerable to Cross-Origin Resource Sharing (CORS) related attacks, potentially allowing malicious websites to read sensitive data or execute actions on behalf of users.
🛡️ **Solution:** Replaced the wildcard `*` with an `ALLOWED_ORIGINS` environment variable that dynamically provides allowed domains as a comma-separated list. It safely defaults to `http://localhost:3000,https://roneira.ai`.

---
*PR created automatically by Jules for task [9845012840913312355](https://jules.google.com/task/9845012840913312355) started by @aaron-seq*